### PR TITLE
Stopped Tornado from starting up when PrawOAuth2Mini is imported

### DIFF
--- a/prawoauth2/PrawOAuth2Server.py
+++ b/prawoauth2/PrawOAuth2Server.py
@@ -7,6 +7,7 @@ import tornado.web
 
 __all__ = ['PrawOAuth2Server']
 
+application = None
 REDIRECT_URL = 'http://127.0.0.1:65010/authorize_callback'
 SCOPES = ['identity']
 REFRESHABLE = True
@@ -49,6 +50,12 @@ class PrawOAuth2Server:
             use `PrawOAuth2Server` again to generate new `access_token`.
             Default is `True`.
         """
+        
+        application = tornado.web.Application([
+            (r'/authorize_callback', AuthorizationHandler),
+        ])
+        application.listen(65010)
+        
         self.reddit_client = reddit_client
         self.app_key = app_key
         self.app_secret = app_secret
@@ -90,8 +97,3 @@ class PrawOAuth2Server:
         :returns: A dictionary containing `access_token` and `refresh_token`.
         """
         return self.reddit_client.get_access_information(code=self.code)
-
-application = tornado.web.Application([
-    (r'/authorize_callback', AuthorizationHandler),
-])
-application.listen(65010)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-praw==3.1.0
+praw==3.2.1
 tornado==4.2


### PR DESCRIPTION
I moved the code that initializes the Tornado server for PrawOAuth2Server into its class body to prevent it from executing when a user imports PrawOAuth2Mini. 

I realized it was running when I imported _only_ PrawOAuth2Mini as I attempted to deploy a web app I wrote up a while back that uses both Flask and prawoauth2 in its backend, and ended up having issues with Tornado binding multiple times to the same port.

Pretty small code change, but it obviously can fix some issues for certain setups.

I also updated the PRAW version requirement in requirements.txt, since that newer version of PRAW seems to work fine with prawoauth2.
